### PR TITLE
Add email/password authentication alongside Google OAuth

### DIFF
--- a/frontend/lib/auth/cognito-client.ts
+++ b/frontend/lib/auth/cognito-client.ts
@@ -1,9 +1,12 @@
 import {
   CognitoIdentityProviderClient,
+  ConfirmForgotPasswordCommand,
+  ForgotPasswordCommand,
   GetUserCommand,
   GlobalSignOutCommand,
   InitiateAuthCommand,
   type InitiateAuthCommandInput,
+  RespondToAuthChallengeCommand,
 } from '@aws-sdk/client-cognito-identity-provider'
 import { cognitoConfig } from './cognito-config'
 
@@ -72,6 +75,55 @@ export class CognitoAuthClient {
     try {
       const command = new GlobalSignOutCommand({
         AccessToken: accessToken,
+      })
+      const response = await this.client.send(command)
+      return { success: true, data: response }
+    }
+    catch (error) {
+      return { success: false, error: error as Error }
+    }
+  }
+
+  async respondToNewPasswordChallenge(email: string, newPassword: string, session: string) {
+    try {
+      const command = new RespondToAuthChallengeCommand({
+        ClientId: cognitoConfig.userPoolWebClientId,
+        ChallengeName: 'NEW_PASSWORD_REQUIRED',
+        Session: session,
+        ChallengeResponses: {
+          USERNAME: email,
+          NEW_PASSWORD: newPassword,
+        },
+      })
+      const response = await this.client.send(command)
+      return { success: true, data: response }
+    }
+    catch (error) {
+      return { success: false, error: error as Error }
+    }
+  }
+
+  async forgotPassword(email: string) {
+    try {
+      const command = new ForgotPasswordCommand({
+        ClientId: cognitoConfig.userPoolWebClientId,
+        Username: email,
+      })
+      const response = await this.client.send(command)
+      return { success: true, data: response }
+    }
+    catch (error) {
+      return { success: false, error: error as Error }
+    }
+  }
+
+  async confirmForgotPassword(email: string, code: string, newPassword: string) {
+    try {
+      const command = new ConfirmForgotPasswordCommand({
+        ClientId: cognitoConfig.userPoolWebClientId,
+        Username: email,
+        ConfirmationCode: code,
+        Password: newPassword,
       })
       const response = await this.client.send(command)
       return { success: true, data: response }

--- a/frontend/lib/auth/cognito-config.ts
+++ b/frontend/lib/auth/cognito-config.ts
@@ -6,9 +6,8 @@ import {
   PUBLIC_COGNITO_IDENTITY_POOL_ID,
   PUBLIC_COGNITO_USER_POOL_CLIENT_ID,
   PUBLIC_COGNITO_USER_POOL_ID,
-  PUBLIC_GUEST_EMAIL,
-  PUBLIC_GUEST_PASSWORD,
 } from '$env/static/public'
+import { env } from '$env/dynamic/public'
 
 // AWS Cognito Configuration
 export const cognitoConfig = {
@@ -19,8 +18,9 @@ export const cognitoConfig = {
   apiGatewayUrl: PUBLIC_API_GATEWAY_URL || '',
   hostedUIUrl: PUBLIC_COGNITO_HOSTED_UI_URL || '',
   hostedUIDomain: PUBLIC_COGNITO_HOSTED_UI_DOMAIN || '',
-  guestEmail: PUBLIC_GUEST_EMAIL || '',
-  guestPassword: PUBLIC_GUEST_PASSWORD || '',
+  // Guest login uses dynamic env (optional, won't fail build if missing)
+  guestEmail: env.PUBLIC_GUEST_EMAIL || '',
+  guestPassword: env.PUBLIC_GUEST_PASSWORD || '',
 }
 
 export function isGuestLoginEnabled(): boolean {

--- a/frontend/lib/auth/cognito-config.ts
+++ b/frontend/lib/auth/cognito-config.ts
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/public'
 import {
   PUBLIC_API_GATEWAY_URL,
   PUBLIC_AWS_REGION,
@@ -7,7 +8,6 @@ import {
   PUBLIC_COGNITO_USER_POOL_CLIENT_ID,
   PUBLIC_COGNITO_USER_POOL_ID,
 } from '$env/static/public'
-import { env } from '$env/dynamic/public'
 
 // AWS Cognito Configuration
 export const cognitoConfig = {

--- a/frontend/lib/components/auth/LoginForm.svelte
+++ b/frontend/lib/components/auth/LoginForm.svelte
@@ -1,0 +1,330 @@
+<script lang='ts'>
+  import { goto } from '$app/navigation'
+  import { authService } from '$lib/auth/auth-service'
+  import { isCognitoConfigured, isGuestLoginEnabled } from '$lib/auth/cognito-config'
+  import { googleOAuth } from '$lib/auth/google-oauth'
+
+  let email = ''
+  let password = ''
+  let newPassword = ''
+  let confirmPassword = ''
+  let error = ''
+  let loading = false
+  let guestLoading = false
+
+  // For NEW_PASSWORD_REQUIRED challenge
+  let pendingChallenge: { session: string, email: string } | null = null
+
+  const guestEnabled = isGuestLoginEnabled()
+
+  async function handleEmailLogin() {
+    if (!email || !password) {
+      error = 'Please enter email and password'
+      return
+    }
+
+    loading = true
+    error = ''
+
+    try {
+      if (!isCognitoConfigured()) {
+        error = 'Authentication is not configured'
+        return
+      }
+
+      const result = await authService.signIn(email, password)
+
+      if (!result.success && result.challengeName === 'NEW_PASSWORD_REQUIRED') {
+        pendingChallenge = { session: result.session, email: result.email }
+        password = '' // Clear temp password
+        return
+      }
+
+      // Success - redirect handled by parent page via auth store subscription
+    }
+    catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed'
+      if (message.includes('Incorrect username or password')) {
+        error = 'Invalid email or password'
+      } else if (message.includes('User does not exist')) {
+        error = 'No account found with this email'
+      } else if (message.includes('Password attempts exceeded')) {
+        error = 'Too many failed attempts. Please try again later.'
+      } else {
+        error = message
+      }
+    }
+    finally {
+      loading = false
+    }
+  }
+
+  async function handleSetNewPassword() {
+    if (!newPassword || !confirmPassword) {
+      error = 'Please enter and confirm your new password'
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      error = 'Passwords do not match'
+      return
+    }
+
+    if (newPassword.length < 8) {
+      error = 'Password must be at least 8 characters'
+      return
+    }
+
+    loading = true
+    error = ''
+
+    try {
+      if (!pendingChallenge) {
+        error = 'Session expired. Please try logging in again.'
+        return
+      }
+
+      await authService.completeNewPasswordChallenge(
+        pendingChallenge.email,
+        newPassword,
+        pendingChallenge.session
+      )
+
+      // Success - redirect handled by parent page
+    }
+    catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to set password'
+      if (message.includes('Password does not conform')) {
+        error = 'Password must include uppercase, lowercase, and numbers'
+      } else {
+        error = message
+      }
+    }
+    finally {
+      loading = false
+    }
+  }
+
+  async function handleGoogleLogin() {
+    try {
+      if (!isCognitoConfigured()) {
+        error = 'Authentication is not configured'
+        return
+      }
+      googleOAuth.loginWithGoogle()
+    }
+    catch (err) {
+      error = err instanceof Error ? err.message : 'Google login failed'
+    }
+  }
+
+  async function handleGuestLogin() {
+    guestLoading = true
+    error = ''
+    try {
+      await authService.signInAsGuest()
+    }
+    catch (err) {
+      error = err instanceof Error ? err.message : 'Guest login failed'
+    }
+    finally {
+      guestLoading = false
+    }
+  }
+
+  function cancelChallenge() {
+    pendingChallenge = null
+    newPassword = ''
+    confirmPassword = ''
+    error = ''
+  }
+</script>
+
+<div class='w-full bg-base-100 card mx-auto shadow-xl max-w-md'>
+  <div class='card-body'>
+    <h2 class='justify-center mb-4 card-title'>
+      {#if pendingChallenge}
+        Set New Password
+      {:else}
+        Sign In
+      {/if}
+    </h2>
+
+    {#if pendingChallenge}
+      <!-- New Password Form (first login with temp password) -->
+      <form on:submit|preventDefault={handleSetNewPassword} class='space-y-4'>
+        <p class='text-sm text-base-content/70'>
+          Please set a new password for your account.
+        </p>
+
+        <div class='form-control'>
+          <label class='label' for='newPassword'>
+            <span class='label-text'>New Password</span>
+          </label>
+          <input
+            id='newPassword'
+            type='password'
+            bind:value={newPassword}
+            class='input input-bordered w-full'
+            placeholder='Enter new password'
+            disabled={loading}
+            autocomplete='new-password'
+          />
+        </div>
+
+        <div class='form-control'>
+          <label class='label' for='confirmPassword'>
+            <span class='label-text'>Confirm Password</span>
+          </label>
+          <input
+            id='confirmPassword'
+            type='password'
+            bind:value={confirmPassword}
+            class='input input-bordered w-full'
+            placeholder='Confirm new password'
+            disabled={loading}
+            autocomplete='new-password'
+          />
+        </div>
+
+        <p class='text-xs text-base-content/60'>
+          Password must be at least 8 characters with uppercase, lowercase, and numbers.
+        </p>
+
+        <button
+          type='submit'
+          class='w-full btn btn-primary'
+          disabled={loading}
+        >
+          {#if loading}
+            <span class='loading loading-spinner'></span>
+            Setting password...
+          {:else}
+            Set Password
+          {/if}
+        </button>
+
+        <button
+          type='button'
+          class='w-full btn btn-ghost btn-sm'
+          on:click={cancelChallenge}
+          disabled={loading}
+        >
+          Cancel
+        </button>
+      </form>
+    {:else}
+      <!-- Standard Login Form -->
+      <div class='space-y-4'>
+        {#if guestEnabled}
+          <button
+            type='button'
+            class='w-full btn btn-primary gap-2 text-lg py-4 h-auto'
+            on:click={handleGuestLogin}
+            disabled={guestLoading}
+          >
+            {#if guestLoading}
+              <span class='loading loading-spinner'></span>
+              Signing in...
+            {:else}
+              <svg class='w-6 h-6' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
+                <path d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2' />
+                <circle cx='12' cy='7' r='4' />
+              </svg>
+              Continue as Guest
+            {/if}
+          </button>
+          <div class='divider'>or</div>
+        {/if}
+
+        <form on:submit|preventDefault={handleEmailLogin} class='space-y-4'>
+          <div class='form-control'>
+            <label class='label' for='email'>
+              <span class='label-text'>Email</span>
+            </label>
+            <input
+              id='email'
+              type='email'
+              bind:value={email}
+              class='input input-bordered w-full'
+              placeholder='Enter your email'
+              disabled={loading}
+              autocomplete='email'
+            />
+          </div>
+
+          <div class='form-control'>
+            <label class='label' for='password'>
+              <span class='label-text'>Password</span>
+            </label>
+            <input
+              id='password'
+              type='password'
+              bind:value={password}
+              class='input input-bordered w-full'
+              placeholder='Enter your password'
+              disabled={loading}
+              autocomplete='current-password'
+            />
+            <label class='label'>
+              <a href='/auth/forgot-password' class='label-text-alt link link-hover'>
+                Forgot password?
+              </a>
+            </label>
+          </div>
+
+          <button
+            type='submit'
+            class='w-full btn btn-primary'
+            disabled={loading}
+          >
+            {#if loading}
+              <span class='loading loading-spinner'></span>
+              Signing in...
+            {:else}
+              Sign In
+            {/if}
+          </button>
+        </form>
+
+        <div class='divider'>or</div>
+
+        <button
+          type='button'
+          class='w-full btn btn-outline gap-2'
+          on:click={handleGoogleLogin}
+        >
+          <svg class='w-5 h-5' viewBox='0 0 24 24'>
+            <path fill='currentColor' d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z' />
+            <path fill='currentColor' d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z' />
+            <path fill='currentColor' d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z' />
+            <path fill='currentColor' d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z' />
+          </svg>
+          Continue with Google
+        </button>
+      </div>
+    {/if}
+
+    {#if error}
+      <div class='mt-4 alert alert-error'>
+        <span>{error}</span>
+      </div>
+    {/if}
+
+    {#if !pendingChallenge}
+      <div class='divider'>Access Information</div>
+
+      <div class='space-y-2 text-center'>
+        <div class='alert alert-info'>
+          <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' class='w-6 h-6 stroke-current shrink-0'>
+            <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'></path>
+          </svg>
+          <div class='text-sm'>
+            <p><strong>Restricted Access:</strong> Only authorized users can sign in</p>
+            <p class='mt-1'>Contact your administrator if you need access.</p>
+          </div>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/lib/components/auth/LoginForm.svelte
+++ b/frontend/lib/components/auth/LoginForm.svelte
@@ -1,5 +1,4 @@
 <script lang='ts'>
-  import { goto } from '$app/navigation'
   import { authService } from '$lib/auth/auth-service'
   import { isCognitoConfigured, isGuestLoginEnabled } from '$lib/auth/cognito-config'
   import { googleOAuth } from '$lib/auth/google-oauth'
@@ -37,7 +36,6 @@
       if (!result.success && result.challengeName === 'NEW_PASSWORD_REQUIRED') {
         pendingChallenge = { session: result.session, email: result.email }
         password = '' // Clear temp password
-        return
       }
 
       // Success - redirect handled by parent page via auth store subscription
@@ -46,11 +44,14 @@
       const message = err instanceof Error ? err.message : 'Login failed'
       if (message.includes('Incorrect username or password')) {
         error = 'Invalid email or password'
-      } else if (message.includes('User does not exist')) {
+      }
+ else if (message.includes('User does not exist')) {
         error = 'No account found with this email'
-      } else if (message.includes('Password attempts exceeded')) {
+      }
+ else if (message.includes('Password attempts exceeded')) {
         error = 'Too many failed attempts. Please try again later.'
-      } else {
+      }
+ else {
         error = message
       }
     }
@@ -87,7 +88,7 @@
       await authService.completeNewPasswordChallenge(
         pendingChallenge.email,
         newPassword,
-        pendingChallenge.session
+        pendingChallenge.session,
       )
 
       // Success - redirect handled by parent page
@@ -96,7 +97,8 @@
       const message = err instanceof Error ? err.message : 'Failed to set password'
       if (message.includes('Password does not conform')) {
         error = 'Password must include uppercase, lowercase, and numbers'
-      } else {
+      }
+ else {
         error = message
       }
     }

--- a/frontend/routes/auth/forgot-password/+page.svelte
+++ b/frontend/routes/auth/forgot-password/+page.svelte
@@ -1,0 +1,135 @@
+<script lang='ts'>
+  import { goto } from '$app/navigation'
+  import { authService } from '$lib/auth/auth-service'
+
+  let email = ''
+  let error = ''
+  let loading = false
+  let submitted = false
+
+  async function handleSubmit() {
+    if (!email) {
+      error = 'Please enter your email address'
+      return
+    }
+
+    loading = true
+    error = ''
+
+    try {
+      await authService.forgotPassword(email)
+      submitted = true
+      // Store email for the reset page
+      sessionStorage.setItem('reset_password_email', email)
+    }
+    catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send reset code'
+      if (message.includes('User does not exist')) {
+        // Don't reveal if user exists - just show success
+        submitted = true
+        sessionStorage.setItem('reset_password_email', email)
+      } else if (message.includes('Attempt limit exceeded')) {
+        error = 'Too many attempts. Please try again later.'
+      } else {
+        error = message
+      }
+    }
+    finally {
+      loading = false
+    }
+  }
+
+  function goToReset() {
+    goto('/auth/reset-password')
+  }
+</script>
+
+<svelte:head>
+  <title>Forgot Password</title>
+  <meta name='description' content='Reset your password' />
+</svelte:head>
+
+<div class='min-h-screen flex items-center justify-center bg-base-200 px-4'>
+  <div class='w-full bg-base-100 card mx-auto shadow-xl max-w-md'>
+    <div class='card-body'>
+      <h2 class='justify-center mb-4 card-title'>Forgot Password</h2>
+
+      {#if submitted}
+        <div class='space-y-4'>
+          <div class='alert alert-success'>
+            <svg xmlns='http://www.w3.org/2000/svg' class='stroke-current shrink-0 h-6 w-6' fill='none' viewBox='0 0 24 24'>
+              <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' />
+            </svg>
+            <span>If an account exists for {email}, a reset code has been sent.</span>
+          </div>
+
+          <p class='text-sm text-base-content/70'>
+            Check your email for a verification code, then click below to reset your password.
+          </p>
+
+          <button
+            type='button'
+            class='w-full btn btn-primary'
+            on:click={goToReset}
+          >
+            Enter Reset Code
+          </button>
+
+          <button
+            type='button'
+            class='w-full btn btn-ghost btn-sm'
+            on:click={() => { submitted = false; error = '' }}
+          >
+            Try a different email
+          </button>
+        </div>
+      {:else}
+        <form on:submit|preventDefault={handleSubmit} class='space-y-4'>
+          <p class='text-sm text-base-content/70'>
+            Enter your email address and we'll send you a code to reset your password.
+          </p>
+
+          <div class='form-control'>
+            <label class='label' for='email'>
+              <span class='label-text'>Email</span>
+            </label>
+            <input
+              id='email'
+              type='email'
+              bind:value={email}
+              class='input input-bordered w-full'
+              placeholder='Enter your email'
+              disabled={loading}
+              autocomplete='email'
+            />
+          </div>
+
+          {#if error}
+            <div class='alert alert-error'>
+              <span>{error}</span>
+            </div>
+          {/if}
+
+          <button
+            type='submit'
+            class='w-full btn btn-primary'
+            disabled={loading}
+          >
+            {#if loading}
+              <span class='loading loading-spinner'></span>
+              Sending...
+            {:else}
+              Send Reset Code
+            {/if}
+          </button>
+
+          <div class='text-center'>
+            <a href='/auth/login' class='link link-hover text-sm'>
+              Back to Sign In
+            </a>
+          </div>
+        </form>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/frontend/routes/auth/forgot-password/+page.svelte
+++ b/frontend/routes/auth/forgot-password/+page.svelte
@@ -28,9 +28,11 @@
         // Don't reveal if user exists - just show success
         submitted = true
         sessionStorage.setItem('reset_password_email', email)
-      } else if (message.includes('Attempt limit exceeded')) {
+      }
+ else if (message.includes('Attempt limit exceeded')) {
         error = 'Too many attempts. Please try again later.'
-      } else {
+      }
+ else {
         error = message
       }
     }
@@ -78,7 +80,10 @@
           <button
             type='button'
             class='w-full btn btn-ghost btn-sm'
-            on:click={() => { submitted = false; error = '' }}
+            on:click={() => {
+              submitted = false
+              error = ''
+            }}
           >
             Try a different email
           </button>

--- a/frontend/routes/auth/login/+page.svelte
+++ b/frontend/routes/auth/login/+page.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
   import { goto } from '$app/navigation'
   import { isAuthenticated } from '$lib/auth/auth-store'
-  import GoogleLoginForm from '$lib/components/auth/GoogleLoginForm.svelte'
+  import LoginForm from '$lib/components/auth/LoginForm.svelte'
   import { onMount } from 'svelte'
 
   onMount(() => {
@@ -30,5 +30,5 @@
 </svelte:head>
 
 <div class='min-h-screen flex items-center justify-center bg-base-200 px-4'>
-  <GoogleLoginForm />
+  <LoginForm />
 </div>

--- a/frontend/routes/auth/reset-password/+page.svelte
+++ b/frontend/routes/auth/reset-password/+page.svelte
@@ -1,0 +1,209 @@
+<script lang='ts'>
+  import { goto } from '$app/navigation'
+  import { authService } from '$lib/auth/auth-service'
+  import { onMount } from 'svelte'
+
+  let email = ''
+  let code = ''
+  let newPassword = ''
+  let confirmPassword = ''
+  let error = ''
+  let loading = false
+  let success = false
+
+  onMount(() => {
+    // Get email from session storage (set by forgot-password page)
+    const storedEmail = sessionStorage.getItem('reset_password_email')
+    if (storedEmail) {
+      email = storedEmail
+    }
+  })
+
+  async function handleSubmit() {
+    error = ''
+
+    if (!email) {
+      error = 'Please enter your email address'
+      return
+    }
+
+    if (!code) {
+      error = 'Please enter the verification code'
+      return
+    }
+
+    if (!newPassword || !confirmPassword) {
+      error = 'Please enter and confirm your new password'
+      return
+    }
+
+    if (newPassword !== confirmPassword) {
+      error = 'Passwords do not match'
+      return
+    }
+
+    if (newPassword.length < 8) {
+      error = 'Password must be at least 8 characters'
+      return
+    }
+
+    loading = true
+
+    try {
+      await authService.resetPassword(email, code, newPassword)
+      success = true
+      sessionStorage.removeItem('reset_password_email')
+    }
+    catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reset password'
+      if (message.includes('Invalid verification code')) {
+        error = 'Invalid or expired verification code'
+      } else if (message.includes('Password does not conform')) {
+        error = 'Password must include uppercase, lowercase, and numbers'
+      } else if (message.includes('Attempt limit exceeded')) {
+        error = 'Too many attempts. Please request a new code.'
+      } else {
+        error = message
+      }
+    }
+    finally {
+      loading = false
+    }
+  }
+
+  function goToLogin() {
+    goto('/auth/login')
+  }
+</script>
+
+<svelte:head>
+  <title>Reset Password</title>
+  <meta name='description' content='Reset your password' />
+</svelte:head>
+
+<div class='min-h-screen flex items-center justify-center bg-base-200 px-4'>
+  <div class='w-full bg-base-100 card mx-auto shadow-xl max-w-md'>
+    <div class='card-body'>
+      <h2 class='justify-center mb-4 card-title'>Reset Password</h2>
+
+      {#if success}
+        <div class='space-y-4'>
+          <div class='alert alert-success'>
+            <svg xmlns='http://www.w3.org/2000/svg' class='stroke-current shrink-0 h-6 w-6' fill='none' viewBox='0 0 24 24'>
+              <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' />
+            </svg>
+            <span>Your password has been reset successfully!</span>
+          </div>
+
+          <button
+            type='button'
+            class='w-full btn btn-primary'
+            on:click={goToLogin}
+          >
+            Sign In
+          </button>
+        </div>
+      {:else}
+        <form on:submit|preventDefault={handleSubmit} class='space-y-4'>
+          <p class='text-sm text-base-content/70'>
+            Enter the verification code from your email and your new password.
+          </p>
+
+          <div class='form-control'>
+            <label class='label' for='email'>
+              <span class='label-text'>Email</span>
+            </label>
+            <input
+              id='email'
+              type='email'
+              bind:value={email}
+              class='input input-bordered w-full'
+              placeholder='Enter your email'
+              disabled={loading}
+              autocomplete='email'
+            />
+          </div>
+
+          <div class='form-control'>
+            <label class='label' for='code'>
+              <span class='label-text'>Verification Code</span>
+            </label>
+            <input
+              id='code'
+              type='text'
+              bind:value={code}
+              class='input input-bordered w-full'
+              placeholder='Enter 6-digit code'
+              disabled={loading}
+              autocomplete='one-time-code'
+              inputmode='numeric'
+              maxlength='6'
+            />
+          </div>
+
+          <div class='form-control'>
+            <label class='label' for='newPassword'>
+              <span class='label-text'>New Password</span>
+            </label>
+            <input
+              id='newPassword'
+              type='password'
+              bind:value={newPassword}
+              class='input input-bordered w-full'
+              placeholder='Enter new password'
+              disabled={loading}
+              autocomplete='new-password'
+            />
+          </div>
+
+          <div class='form-control'>
+            <label class='label' for='confirmPassword'>
+              <span class='label-text'>Confirm Password</span>
+            </label>
+            <input
+              id='confirmPassword'
+              type='password'
+              bind:value={confirmPassword}
+              class='input input-bordered w-full'
+              placeholder='Confirm new password'
+              disabled={loading}
+              autocomplete='new-password'
+            />
+          </div>
+
+          <p class='text-xs text-base-content/60'>
+            Password must be at least 8 characters with uppercase, lowercase, and numbers.
+          </p>
+
+          {#if error}
+            <div class='alert alert-error'>
+              <span>{error}</span>
+            </div>
+          {/if}
+
+          <button
+            type='submit'
+            class='w-full btn btn-primary'
+            disabled={loading}
+          >
+            {#if loading}
+              <span class='loading loading-spinner'></span>
+              Resetting...
+            {:else}
+              Reset Password
+            {/if}
+          </button>
+
+          <div class='flex justify-between text-sm'>
+            <a href='/auth/forgot-password' class='link link-hover'>
+              Request new code
+            </a>
+            <a href='/auth/login' class='link link-hover'>
+              Back to Sign In
+            </a>
+          </div>
+        </form>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/frontend/routes/auth/reset-password/+page.svelte
+++ b/frontend/routes/auth/reset-password/+page.svelte
@@ -58,11 +58,14 @@
       const message = err instanceof Error ? err.message : 'Failed to reset password'
       if (message.includes('Invalid verification code')) {
         error = 'Invalid or expired verification code'
-      } else if (message.includes('Password does not conform')) {
+      }
+ else if (message.includes('Password does not conform')) {
         error = 'Password must include uppercase, lowercase, and numbers'
-      } else if (message.includes('Attempt limit exceeded')) {
+      }
+ else if (message.includes('Attempt limit exceeded')) {
         error = 'Too many attempts. Please request a new code.'
-      } else {
+      }
+ else {
         error = message
       }
     }


### PR DESCRIPTION
- Add Cognito commands for password challenges and reset flows
- Create unified LoginForm with email/password and Google OAuth options
- Handle NEW_PASSWORD_REQUIRED challenge for admin-created users
- Add forgot-password and reset-password pages
- Fix guest login env vars to use dynamic imports (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step sign-in flow that handles immediate password-change challenges and lets users complete a new-password step inline.
  * New "Forgot Password" page to request a reset email.
  * New "Reset Password" page to submit a verification code and set a new password.
  * Updated login UI combining standard, guest, and Google sign-in with enhanced error and loading states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->